### PR TITLE
fix: Prevent E95 error by ensuring unique buffer names

### DIFF
--- a/lua/npm_scripts/init.lua
+++ b/lua/npm_scripts/init.lua
@@ -57,8 +57,15 @@ function utils.get_opts(local_options)
                 return
             else
                 vim.cmd('tabnew | term ' .. cmd)
-                -- rename buffer
-                vim.cmd.file(opts.package_manager .. ':' .. opts.name)
+                -- rename buffer, ensuring uniqueness
+                local base_name = opts.package_manager .. ':' .. opts.name
+                local final_name = base_name
+                local i = 2
+                while vim.fn.bufexists(final_name) == 1 do
+                    final_name = base_name .. '_' .. i
+                    i = i + 1
+                end
+                vim.cmd.file(final_name)
             end
         end,
     }


### PR DESCRIPTION
Running the same script more than once in the same session would result in the following error:
```
Error executing vim.schedule lua callback: ...hare/nvim/lazy/npm_scripts.nvim/lua/npm_scripts/init.lua:61: Vim:E95: Buffer with this name already exists
stack traceback:
        [C]: in function 'file'
        ...hare/nvim/lazy/npm_scripts.nvim/lua/npm_scripts/init.lua:61: in function 'run_script'
        ...hare/nvim/lazy/npm_scripts.nvim/lua/npm_scripts/init.lua:416: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

This commit would simple append _2, _3, etc.. if there's an existing buffer with the expected name.